### PR TITLE
IOS-11 Custom Font Axis Formatter

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Documentation
+# https://help.github.com/en/articles/about-code-owners
+
+* @foldmoney/ios

--- a/Source/Charts/Components/AxisBase.swift
+++ b/Source/Charts/Components/AxisBase.swift
@@ -171,6 +171,8 @@ open class AxisBase: ComponentBase
         }
     }
     
+    open var labelFormatter: AxisLabelFormatter?
+    
     @objc open var isDrawGridLinesEnabled: Bool { return drawGridLinesEnabled }
     
     @objc open var isDrawAxisLineEnabled: Bool { return drawAxisLineEnabled }

--- a/Source/Charts/Formatters/AxisLabelFormatter.swift
+++ b/Source/Charts/Formatters/AxisLabelFormatter.swift
@@ -1,0 +1,13 @@
+//
+//  AxisLabelFormatter.swift
+//  
+//
+//  Created by Sharath Sriram on 12/03/23.
+//
+
+import Foundation
+
+public protocol AxisLabelFormatter: AnyObject {
+    /// Called to format the font of the label being drawn on the axis
+    func attributesForAxis() -> [NSAttributedString.Key : Any]
+}

--- a/Source/Charts/Formatters/AxisLabelFormatter.swift
+++ b/Source/Charts/Formatters/AxisLabelFormatter.swift
@@ -9,5 +9,5 @@ import Foundation
 
 public protocol AxisLabelFormatter: AnyObject {
     /// Called to format the font of the label being drawn on the axis
-    func attributesForAxis() -> [NSAttributedString.Key : Any]
+    func attributesForAxis(value: Double) -> [NSAttributedString.Key : Any]
 }

--- a/Source/Charts/Formatters/AxisLabelFormatter.swift
+++ b/Source/Charts/Formatters/AxisLabelFormatter.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public protocol AxisLabelFormatter: AnyObject {
+public protocol AxisLabelFormatter {
     /// Called to format the font of the label being drawn on the axis
     func attributesForAxis(value: Double) -> [NSAttributedString.Key : Any]
 }

--- a/Source/Charts/Renderers/XAxisRenderer.swift
+++ b/Source/Charts/Renderers/XAxisRenderer.swift
@@ -252,9 +252,17 @@ open class XAxisRenderer: NSObject, AxisRenderer
         let paraStyle = ParagraphStyle.default.mutableCopy() as! MutableParagraphStyle
         paraStyle.alignment = .center
         
-        let labelAttrs: [NSAttributedString.Key : Any] = [.font: axis.labelFont,
-                                                         .foregroundColor: axis.labelTextColor,
-                                                         .paragraphStyle: paraStyle]
+        var labelAttrs: [NSAttributedString.Key : Any] = [:]
+        
+        if let attributes = axis.labelFormatter?.attributesForAxis() {
+            labelAttrs = attributes
+            labelAttrs[.paragraphStyle] = paraStyle
+        }
+        else {
+            labelAttrs = [.font: axis.labelFont,
+                                                             .foregroundColor: axis.labelTextColor,
+                                                             .paragraphStyle: paraStyle]
+        }
 
         let labelRotationAngleRadians = axis.labelRotationAngle.DEG2RAD
         let isCenteringEnabled = axis.isCenterAxisLabelsEnabled

--- a/Source/Charts/Renderers/XAxisRenderer.swift
+++ b/Source/Charts/Renderers/XAxisRenderer.swift
@@ -252,17 +252,6 @@ open class XAxisRenderer: NSObject, AxisRenderer
         let paraStyle = ParagraphStyle.default.mutableCopy() as! MutableParagraphStyle
         paraStyle.alignment = .center
         
-        var labelAttrs: [NSAttributedString.Key : Any] = [:]
-        
-        if let attributes = axis.labelFormatter?.attributesForAxis() {
-            labelAttrs = attributes
-            labelAttrs[.paragraphStyle] = paraStyle
-        }
-        else {
-            labelAttrs = [.font: axis.labelFont,
-                                                             .foregroundColor: axis.labelTextColor,
-                                                             .paragraphStyle: paraStyle]
-        }
 
         let labelRotationAngleRadians = axis.labelRotationAngle.DEG2RAD
         let isCenteringEnabled = axis.isCenterAxisLabelsEnabled
@@ -280,6 +269,16 @@ open class XAxisRenderer: NSObject, AxisRenderer
         
         for i in entries.indices
         {
+            var labelAttrs: [NSAttributedString.Key : Any] = [:]
+            if let attributes = axis.labelFormatter?.attributesForAxis(value: axis.entries[i]) {
+                labelAttrs = attributes
+                labelAttrs[.paragraphStyle] = paraStyle
+            }
+            else {
+                labelAttrs = [.font: axis.labelFont,
+                                                                 .foregroundColor: axis.labelTextColor,
+                                                                 .paragraphStyle: paraStyle]
+            }
             let px = isCenteringEnabled ? CGFloat(axis.centeredEntries[i]) : CGFloat(entries[i])
             position = CGPoint(x: px, y: 0)
                 .applying(valueToPixelMatrix)


### PR DESCRIPTION
## Description

Adds functionality to support dynamic font choice for axis labels. The design is similar to the axis value formatter which chooses the text to display. Here, instead of text, we take in an array of font customisation options and apply it to the label

## How has this been tested?

Tested with the main repo by setting custom color choices  

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
